### PR TITLE
Removed Twitter, Website, and Resume links from Brenden Wang's profile.

### DIFF
--- a/team/brenden_wang.md
+++ b/team/brenden_wang.md
@@ -9,9 +9,6 @@
 
 - [GitHub](https://github.com/Brenden-Yiping-Wang)
 - [LinkedIn](https://www.linkedin.com/in/brenden-yiping-wang-b9232927b/)
-- [Twitter](#)
-- [Website](#)
-- [Resume](#)
 
 ## About Brenden
 


### PR DESCRIPTION
Removed Twitter, Website, and Resume links from Brenden Wang's profile.